### PR TITLE
workaround "The module 'SqlServer' could not be loaded"

### DIFF
--- a/Request.ps1
+++ b/Request.ps1
@@ -15,6 +15,7 @@ if (Test-Path -Path "C:\demo\*\BcContainerHelper.psm1") {
 } else {
     Import-Module -name bccontainerhelper -DisableNameChecking
 }
+$bcContainerHelperConfig.usePwshForBc24 = $false
 
 . (Join-Path $PSScriptRoot "settings.ps1")
 Add-Type -AssemblyName System.Web

--- a/RunQueue.ps1
+++ b/RunQueue.ps1
@@ -10,6 +10,7 @@ if (Test-Path -Path "C:\demo\*\BcContainerHelper.psm1") {
 } else {
     Import-Module -name bccontainerhelper -DisableNameChecking
 }
+$bcContainerHelperConfig.usePwshForBc24 = $false
 
 $storageContext = New-AzStorageContext -ConnectionString $storageConnectionString
 $queuename = $publicDnsName.Split('.')[0]

--- a/SetupDesktop.ps1
+++ b/SetupDesktop.ps1
@@ -11,6 +11,7 @@ if (Test-Path -Path "C:\demo\*\BcContainerHelper.psm1") {
 } else {
     Import-Module -name bccontainerhelper -DisableNameChecking
 }
+$bcContainerHelperConfig.usePwshForBc24 = $false
 
 . (Join-Path $PSScriptRoot "settings.ps1")
 

--- a/SetupNavContainer.ps1
+++ b/SetupNavContainer.ps1
@@ -155,6 +155,14 @@ else {
                         if (-not $sp) { $sp = New-MgServicePrincipal -AppId $appId }
                     }
                     $app = Get-MgApplication -All | Where-Object { $_.AppId -eq $appId }
+                    if (-not $app) {
+                        Start-Sleep -Seconds 10
+                        $app = Get-MgApplication -All | Where-Object { $_.AppId -eq $appId }
+                    }
+                    if (-not $app) {
+                        AddToStatus -color Yellow "App registration $appId not yet available in directory, skipping consent"
+                        continue
+                    }
                     foreach ($rra in $app.RequiredResourceAccess) {
                         $rsp = Get-MgServicePrincipal -All | Where-Object { $_.AppId -eq $rra.ResourceAppId }
                         if (-not $rsp) { continue }

--- a/SetupNavContainer.ps1
+++ b/SetupNavContainer.ps1
@@ -12,6 +12,7 @@ if (Test-Path -Path "C:\demo\*\BcContainerHelper.psm1") {
 else {
     Import-Module -Name bccontainerhelper -DisableNameChecking
 }
+$bcContainerHelperConfig.usePwshForBc24 = $false
 
 $settingsScript = Join-Path $PSScriptRoot "settings.ps1"
 

--- a/SetupStart.ps1
+++ b/SetupStart.ps1
@@ -47,8 +47,8 @@ if ($nchBranch -eq "preview") {
     AddToStatus ("Using BcContainerHelper version "+(get-module BcContainerHelper).Version.ToString())
 }
 elseif ($nchBranch -eq "") {
-    AddToStatus "Installing BcContainerHelper version 6.1.12 from PowerShell Gallery"
-    Install-Module -Name bccontainerhelper -Force -RequiredVersion 6.1.12
+    AddToStatus "Installing Latest BcContainerHelper from PowerShell Gallery"
+    Install-Module -Name bccontainerhelper -Force
     Import-Module -Name bccontainerhelper -DisableNameChecking
     AddToStatus ("Using BcContainerHelper version "+(get-module BcContainerHelper).Version.ToString())
 } else {
@@ -63,6 +63,13 @@ elseif ($nchBranch -eq "") {
     AddToStatus "Loading BcContainerHelper from $($module.FullName)"
     Import-Module $module.FullName -DisableNameChecking
 }
+
+# Workaround for BcContainerHelper 6.1.13+ breaking change (commit f929f6b):
+# When usePwsh=$true and BC28+, useSession is forced to $false, causing docker exec
+# to use pwsh where Invoke-SqlCmd fails due to missing SqlServer module in PS7.
+# Setting usePwshForBc24=$false keeps docker exec on powershell.exe (PS5) where
+# Invoke-SqlCmd works natively.
+$bcContainerHelperConfig.usePwshForBc24 = $false
 
 if (-not (Get-InstalledModule Az -ErrorAction SilentlyContinue)) {
     AddToStatus "Installing Az module"

--- a/SetupStart.ps1
+++ b/SetupStart.ps1
@@ -47,8 +47,8 @@ if ($nchBranch -eq "preview") {
     AddToStatus ("Using BcContainerHelper version "+(get-module BcContainerHelper).Version.ToString())
 }
 elseif ($nchBranch -eq "") {
-    AddToStatus "Installing Latest Business Central Container Helper from PowerShell Gallery"
-    Install-Module -Name bccontainerhelper -Force
+    AddToStatus "Installing BcContainerHelper version 6.1.12 from PowerShell Gallery"
+    Install-Module -Name bccontainerhelper -Force -RequiredVersion 6.1.12
     Import-Module -Name bccontainerhelper -DisableNameChecking
     AddToStatus ("Using BcContainerHelper version "+(get-module BcContainerHelper).Version.ToString())
 } else {

--- a/SetupVm.ps1
+++ b/SetupVm.ps1
@@ -108,6 +108,7 @@ if (Test-Path -Path "C:\demo\*\BcContainerHelper.psm1") {
 } else {
     Import-Module -name bccontainerhelper -DisableNameChecking
 }
+$bcContainerHelperConfig.usePwshForBc24 = $false
 
 . (Join-Path $PSScriptRoot "settings.ps1")
 
@@ -318,7 +319,8 @@ New-Item $winPsFolder -ItemType Directory -Force -ErrorAction Ignore | Out-Null
     Import-module $module.FullName -DisableNameChecking
 } else {
     Import-Module -name bccontainerhelper -DisableNameChecking
-}' | Set-Content (Join-Path $winPsFolder "Profile.ps1")
+}
+$bcContainerHelperConfig.usePwshForBc24 = $false' | Set-Content (Join-Path $winPsFolder "Profile.ps1")
 
 AddToStatus "Adding Landing Page to Startup Group"
 if ($AddTraefik -eq "Yes") {


### PR DESCRIPTION
Workaround for BcContainerHelper 6.1.13+ breaking change:
When usePwsh=$true and BC28+, useSession is forced to $false, causing docker exec to use pwsh where Invoke-SqlCmd fails due to missing SqlServer module in PS7.
Setting usePwshForBc24=$false keeps docker exec on powershell.exe (PS5) where Invoke-SqlCmd works natively.